### PR TITLE
[WIP] Add support for Alinx AXKU040 dev board

### DIFF
--- a/src/main/scala/devices/xilinx/allinxaxku040mig/AlinxAxku040MIG.scala
+++ b/src/main/scala/devices/xilinx/allinxaxku040mig/AlinxAxku040MIG.scala
@@ -1,0 +1,134 @@
+package sifive.fpgashells.devices.xilinx.allinxaxku040mig
+
+import chisel3._
+import chipsalliance.rocketchip.config.Parameters
+import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.subsystem.{CacheBlockBytes, CrossesToOnlyOneClockDomain}
+import freechips.rocketchip.tilelink.{TLBuffer, TLInwardNode, TLToAXI4}
+import sifive.fpgashells.ip.xilinx.alinx_axku040mig._
+
+case class AlinxAxku040MIGParams(address: Seq[AddressSet])
+
+class AlinxAxku040MIGAuxPads extends Bundle {
+  val sysClockInput = Input(Clock())
+  val sysResetInput = Input(Reset())
+  val AXIaresetn = Input(Bool())
+  val UIClock = Output(Clock())
+  val UISyncedReset = Output(Reset())
+  val MIGCalibComplete = Output(Bool())
+}
+
+class AlinxAxku040MIGIsland(c: AlinxAxku040MIGParams)(implicit p: Parameters)
+    extends LazyModule
+    with CrossesToOnlyOneClockDomain {
+  private val ranges = AddressRange.fromSets(c.address)
+  require(ranges.size == 1, "DDR range must be contiguous")
+  private val offset = ranges.head.base
+
+  override val crossing: ClockCrossingType = AsynchronousCrossing(8)
+
+  val device = new MemoryDevice
+  val node = AXI4SlaveNode(
+    Seq(
+      AXI4SlavePortParameters(
+        slaves = Seq(
+          AXI4SlaveParameters(
+            address = c.address,
+            resources = device.reg,
+            regionType = RegionType.UNCACHED,
+            executable = true,
+            supportsWrite = TransferSizes(1, 256 * 8),
+            supportsRead = TransferSizes(1, 256 * 8)
+          )
+        ),
+        beatBytes = 8
+      )
+    )
+  )
+  lazy val module = new LazyModuleImp(this) {
+
+    val auxio = IO(new AlinxAxku040MIGAuxPads)
+    val ddr4_port = IO(new AlinxAxku040MIGDDRPads)
+
+    private val blackbox = Module(new axku040mig)
+    private val (axi4_async, _) = node.in.head
+
+    ddr4_port <> blackbox.c0_ddr4_intf
+
+    blackbox.c0_sys_clk_i := auxio.sysClockInput
+    blackbox.sys_rst := auxio.sysResetInput
+    blackbox.c0_ddr4_aresetn := auxio.AXIaresetn
+    auxio.UIClock := blackbox.c0_ddr4_ui_clk
+    auxio.UISyncedReset := blackbox.c0_ddr4_ui_clk_sync_rst
+    auxio.MIGCalibComplete := blackbox.c0_init_calib_complete
+
+    val mapped_waddr = axi4_async.aw.bits.addr - offset.U
+    val mapped_raddr = axi4_async.ar.bits.addr - offset.U
+
+    blackbox.c0_ddr4_s_axi_awvalid := axi4_async.aw.valid
+    axi4_async.aw.ready := blackbox.c0_ddr4_s_axi_awready
+    blackbox.c0_ddr4_s_axi_awid := axi4_async.aw.bits.id
+    blackbox.c0_ddr4_s_axi_awburst := axi4_async.aw.bits.burst
+    blackbox.c0_ddr4_s_axi_awprot := axi4_async.aw.bits.prot
+    blackbox.c0_ddr4_s_axi_awlock := axi4_async.aw.bits.lock
+    blackbox.c0_ddr4_s_axi_awlen := axi4_async.aw.bits.len
+    blackbox.c0_ddr4_s_axi_awsize := axi4_async.aw.bits.size
+    blackbox.c0_ddr4_s_axi_awqos := axi4_async.aw.bits.qos
+    blackbox.c0_ddr4_s_axi_awcache := "b0011".U
+    blackbox.c0_ddr4_s_axi_awaddr := mapped_waddr
+
+    blackbox.c0_ddr4_s_axi_wvalid := axi4_async.w.valid
+    axi4_async.w.ready := blackbox.c0_ddr4_s_axi_wready
+    blackbox.c0_ddr4_s_axi_wdata := axi4_async.w.bits.data
+    blackbox.c0_ddr4_s_axi_wstrb := axi4_async.w.bits.strb
+    blackbox.c0_ddr4_s_axi_wlast := axi4_async.w.bits.last
+
+    blackbox.c0_ddr4_s_axi_bready := axi4_async.b.ready
+    axi4_async.b.valid := blackbox.c0_ddr4_s_axi_bvalid
+    axi4_async.b.bits.id := blackbox.c0_ddr4_s_axi_bid
+    axi4_async.b.bits.resp := blackbox.c0_ddr4_s_axi_bresp
+
+    blackbox.c0_ddr4_s_axi_arvalid := axi4_async.ar.valid
+    axi4_async.ar.ready := blackbox.c0_ddr4_s_axi_arready
+    blackbox.c0_ddr4_s_axi_arid := axi4_async.ar.bits.id
+    blackbox.c0_ddr4_s_axi_arburst := axi4_async.ar.bits.burst
+    blackbox.c0_ddr4_s_axi_arprot := axi4_async.ar.bits.prot
+    blackbox.c0_ddr4_s_axi_arlock := axi4_async.ar.bits.lock
+    blackbox.c0_ddr4_s_axi_arlen := axi4_async.ar.bits.len
+    blackbox.c0_ddr4_s_axi_arsize := axi4_async.ar.bits.size
+    blackbox.c0_ddr4_s_axi_arqos := axi4_async.ar.bits.qos
+    blackbox.c0_ddr4_s_axi_arcache := "b0011".U
+    blackbox.c0_ddr4_s_axi_araddr := mapped_raddr
+
+    blackbox.c0_ddr4_s_axi_rready := axi4_async.r.ready
+    axi4_async.r.valid := blackbox.c0_ddr4_s_axi_rvalid
+    axi4_async.r.bits.data := blackbox.c0_ddr4_s_axi_rdata
+    axi4_async.r.bits.resp := blackbox.c0_ddr4_s_axi_rresp
+    axi4_async.r.bits.last := blackbox.c0_ddr4_s_axi_rlast
+    axi4_async.r.bits.id := blackbox.c0_ddr4_s_axi_rid
+  }
+}
+
+class AlinxAxku040MIG(c: AlinxAxku040MIGParams)(implicit p: Parameters) extends LazyModule {
+  private val buffer = LazyModule(new TLBuffer())
+  private val toaxi4 = LazyModule(new TLToAXI4(adapterName = Some("mem")))
+  private val indexer = LazyModule(new AXI4IdIndexer(idBits = 4))
+  private val deint = LazyModule(new AXI4Deinterleaver(p(CacheBlockBytes)))
+  private val yank = LazyModule(new AXI4UserYanker())
+  private val island = LazyModule(new AlinxAxku040MIGIsland(c))
+
+  val node: TLInwardNode = buffer.node
+  island.crossAXI4In(island.node) := yank.node := deint.node := indexer.node := toaxi4.node := buffer.node
+
+  lazy val module = new LazyModuleImp(this) {
+    val auxio = IO(new AlinxAxku040MIGAuxPads)
+    val ddr4_port = IO(new AlinxAxku040MIGDDRPads).suggestName("c0_ddr4")
+
+    auxio <> island.module.auxio
+    ddr4_port <> island.module.ddr4_port
+
+    island.module.clock := auxio.UIClock
+    island.module.reset := auxio.UISyncedReset
+  }
+}

--- a/src/main/scala/ip/xilinx/alinx_axku040mig/axku040mig.scala
+++ b/src/main/scala/ip/xilinx/alinx_axku040mig/axku040mig.scala
@@ -1,0 +1,99 @@
+package sifive.fpgashells.ip.xilinx.alinx_axku040mig
+
+import chisel3._
+import chisel3.experimental.{Analog, ExtModule}
+import chipsalliance.rocketchip.config.Parameters
+import freechips.rocketchip.util.ElaborationArtefacts
+
+// format: off
+class AlinxAxku040MIGDDRPads extends Bundle {
+  // Ordering of fields is significant as it needs to line up with pins in AlinxAxku040Shell
+  val ck_c: UInt       = Output(UInt(1.W))
+  val ck_t: UInt       = Output(UInt(1.W))
+  val cke: UInt        = Output(UInt(1.W))
+  val cs_n: UInt       = Output(UInt(1.W))
+  val act_n: Bool      = Output(Bool())
+  val odt: UInt        = Output(UInt(1.W))
+  val adr: UInt        = Output(UInt(17.W))
+  val ba: UInt         = Output(UInt(2.W))
+  val bg: UInt         = Output(UInt(1.W))
+  val reset_n: Bool    = Output(Bool())
+  val dqs_c: Analog    = Analog(8.W)
+  val dqs_t: Analog    = Analog(8.W)
+  val dq: Analog       = Analog(64.W)
+  val dm_dbi_n: Analog = Analog(8.W)
+}
+
+class axku040mig(implicit val p: Parameters) extends ExtModule {
+  // clock and reset
+  val c0_sys_clk_i: Clock             = IO(Input(Clock()))
+  val sys_rst: Reset                  = IO(Input(Reset()))
+  // slave ports driven by internal MMCM
+  val c0_ddr4_ui_clk: Clock           = IO(Output(Clock()))
+  val c0_ddr4_ui_clk_sync_rst: Reset  = IO(Output(Bool()))
+  // misc
+  val c0_init_calib_complete: Bool    = IO(Output(Bool()))
+  // DDR4 interface
+  val c0_ddr4_intf: Bundle            = IO(new AlinxAxku040MIGDDRPads).suggestName("c0_ddr4")
+  // AXI interface
+  val c0_ddr4_aresetn: Bool           = IO(Input(Bool()))
+  // AXI write address port
+  val c0_ddr4_s_axi_awid: UInt        = IO(Input(UInt(4.W)))
+  val c0_ddr4_s_axi_awaddr: UInt      = IO(Input(UInt(31.W)))
+  val c0_ddr4_s_axi_awlen: UInt       = IO(Input(UInt(8.W)))
+  val c0_ddr4_s_axi_awsize: UInt      = IO(Input(UInt(3.W)))
+  val c0_ddr4_s_axi_awburst: UInt     = IO(Input(UInt(2.W)))
+  val c0_ddr4_s_axi_awlock: UInt      = IO(Input(UInt(1.W)))
+  val c0_ddr4_s_axi_awcache: UInt     = IO(Input(UInt(4.W)))
+  val c0_ddr4_s_axi_awprot: UInt      = IO(Input(UInt(3.W)))
+  val c0_ddr4_s_axi_awqos: UInt       = IO(Input(UInt(4.W)))
+  val c0_ddr4_s_axi_awvalid: Bool     = IO(Input(Bool()))
+  val c0_ddr4_s_axi_awready: Bool     = IO(Output(Bool()))
+  // AXI write data port
+  val c0_ddr4_s_axi_wdata: UInt       = IO(Input(UInt(64.W)))
+  val c0_ddr4_s_axi_wstrb: UInt       = IO(Input(UInt(8.W)))
+  val c0_ddr4_s_axi_wlast: Bool       = IO(Input(Bool()))
+  val c0_ddr4_s_axi_wvalid: Bool      = IO(Input(Bool()))
+  val c0_ddr4_s_axi_wready: Bool      = IO(Output(Bool()))
+  // AXI write response port
+  val c0_ddr4_s_axi_bready: Bool      = IO(Input(Bool()))
+  val c0_ddr4_s_axi_bvalid: Bool      = IO(Output(Bool()))
+  val c0_ddr4_s_axi_bid: UInt         = IO(Output(UInt(4.W)))
+  val c0_ddr4_s_axi_bresp: UInt       = IO(Output(UInt(2.W)))
+  // AXI read address port
+  val c0_ddr4_s_axi_arid: UInt        = IO(Input(UInt(4.W)))
+  val c0_ddr4_s_axi_araddr: UInt      = IO(Input(UInt(31.W)))
+  val c0_ddr4_s_axi_arlen: UInt       = IO(Input(UInt(8.W)))
+  val c0_ddr4_s_axi_arsize: UInt      = IO(Input(UInt(3.W)))
+  val c0_ddr4_s_axi_arburst: UInt     = IO(Input(UInt(2.W)))
+  val c0_ddr4_s_axi_arlock: UInt      = IO(Input(UInt(1.W)))
+  val c0_ddr4_s_axi_arcache: UInt     = IO(Input(UInt(4.W)))
+  val c0_ddr4_s_axi_arprot: UInt      = IO(Input(UInt(3.W)))
+  val c0_ddr4_s_axi_arqos: UInt       = IO(Input(UInt(4.W)))
+  val c0_ddr4_s_axi_arvalid: Bool     = IO(Input(Bool()))
+  val c0_ddr4_s_axi_arready: Bool     = IO(Output(Bool()))
+  // AXI read data port
+  val c0_ddr4_s_axi_rready: Bool      = IO(Input(Bool()))
+  val c0_ddr4_s_axi_rvalid: Bool      = IO(Output(Bool()))
+  val c0_ddr4_s_axi_rdata: UInt       = IO(Output(UInt(64.W)))
+  val c0_ddr4_s_axi_rresp: UInt       = IO(Output(UInt(2.W)))
+  val c0_ddr4_s_axi_rid: UInt         = IO(Output(UInt(4.W)))
+  val c0_ddr4_s_axi_rlast: Bool       = IO(Output(Bool()))
+
+  ElaborationArtefacts.add(
+    "axku040mig.vivado.tcl",
+    """create_ip -vendor xilinx.com -library ip -version 2.2 -name ddr4 -module_name axku040mig -dir $ipdir -force
+      |set_property -dict [list \
+      |CONFIG.C0.DDR4_MemoryPart {MT40A256M16LY-062E} \
+      |CONFIG.C0.DDR4_DataWidth {64} \
+      |CONFIG.C0.DDR4_AxiSelection {true} \
+      |CONFIG.C0.DDR4_AxiDataWidth {64} \
+      |CONFIG.C0.DDR4_AxiAddressWidth {31} \
+      |CONFIG.C0.BANK_GROUP_WIDTH {1} \
+      |CONFIG.C0.DDR4_InputClockPeriod {4998} \
+      |CONFIG.System_Clock {No_Buffer} \
+      |] [get_ips axku040mig]
+      |""".stripMargin
+  )
+}
+// format: on

--- a/src/main/scala/shell/xilinx/AlinxAxku040Shell.scala
+++ b/src/main/scala/shell/xilinx/AlinxAxku040Shell.scala
@@ -1,0 +1,347 @@
+package sifive.fpgashells.shell.xilinx
+
+import chisel3._
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
+import sifive.fpgashells.clocks._
+import sifive.fpgashells.devices.xilinx.allinxaxku040mig.{AlinxAxku040MIG, AlinxAxku040MIGParams}
+import sifive.fpgashells.shell._
+import sifive.fpgashells.ip.xilinx._
+import sifive.fpgashells.ip.xilinx.alinx_axku040mig.AlinxAxku040MIGDDRPads
+
+class SysClockAlinxAxku040PlacedOverlay(
+  val shell:       AlinxAxku040ShellBasicOverlays,
+  name:            String,
+  val designInput: ClockInputDesignInput,
+  val shellInput:  ClockInputShellInput)
+    extends LVDSClockInputXilinxPlacedOverlay(name, designInput, shellInput) {
+  val node = shell { ClockSourceNode(freqMHz = 200, jitterPS = 1.2) }
+
+  shell {
+    InModuleBody {
+      shell.xdc.addPackagePin(io.p, "AK17")
+      shell.xdc.addPackagePin(io.n, "AK16")
+      shell.xdc.addIOStandard(io.p, "LVDS")
+      shell.xdc.addIOStandard(io.n, "LVDS")
+    }
+  }
+}
+
+class SysClockAlinxAxku040ShellPlacer(
+  val shell:      AlinxAxku040ShellBasicOverlays,
+  val shellInput: ClockInputShellInput
+)(
+  implicit val valName: ValName)
+    extends ClockInputShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  override def place(designInput: ClockInputDesignInput) =
+    new SysClockAlinxAxku040PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class RefClockAlinxAxku040PlacedOverlay(val shell: AlinxAxku040ShellBasicOverlays, name: String, val designInput: ClockInputDesignInput, val shellInput: ClockInputShellInput)
+extends LVDSClockInputXilinxPlacedOverlay(name, designInput, shellInput) {
+  val node = shell { ClockSourceNode(freqMHz = 125.00, jitterPS = 1.2) }
+
+  shell { InModuleBody {
+    shell.xdc.addPackagePin(io.p, "AF6")
+    shell.xdc.addPackagePin(io.n, "AF5")
+    shell.xdc.addIOStandard(io.p, "LVDS")
+    shell.xdc.addIOStandard(io.n, "LVDS")
+  }}
+}
+class RefClockAlinxAxku040Placer(val shell: AlinxAxku040ShellBasicOverlays, val shellInput: ClockInputShellInput)(implicit val valName: ValName)
+extends ClockInputShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  def place(designInput: ClockInputDesignInput) = new RefClockAlinxAxku040PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class SPIFlashAlinxAxku040PlacedOverlay(val shell: AlinxAxku040ShellBasicOverlays, name: String, val designInput: SPIFlashDesignInput, val shellInput: SPIFlashShellInput)
+extends SPIFlashXilinxPlacedOverlay(name, designInput, shellInput)
+{
+  shell { InModuleBody {
+    val packagePinsWithIOs = Seq[(String, IOPin)](
+      ("AA9", IOPin(io.qspi_sck)),
+      ("U7", IOPin(io.qspi_cs)),
+      ("AC7", IOPin(io.qspi_dq(0))),
+      ("AB7", IOPin(io.qspi_dq(1))),
+      ("AA7", IOPin(io.qspi_dq(2))),
+      ("Y7", IOPin(io.qspi_dq(3)))
+    )
+
+    packagePinsWithIOs foreach { case (pin, io) =>
+      shell.xdc.addPackagePin(io, pin)
+      // 1.8V to 3.3V conversion is done on board
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+    }
+
+    packagePinsWithIOs.drop(1).map(_._2).foreach { io =>
+      shell.xdc.addIOB(io)
+      shell.xdc.addPullup(io)
+    }
+  }}
+}
+class SPIFlashAlinxAxku040Placer(val shell: AlinxAxku040ShellBasicOverlays, val shellInput: SPIFlashShellInput)(implicit val valName: ValName)
+extends SPIFlashShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  def place(designInput: SPIFlashDesignInput) = new SPIFlashAlinxAxku040PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+object LEDAlinxAxku040PinConstraints {
+  val pins = Seq("L20", "M20", "M21", "N21")
+}
+class LEDAlinxAxku040PlacedOverlay(
+  val shell:       AlinxAxku040ShellBasicOverlays,
+  name:            String,
+  val designInput: LEDDesignInput,
+  val shellInput:  LEDShellInput)
+    extends LEDXilinxPlacedOverlay(
+      name,
+      designInput,
+      shellInput,
+      packagePin = Some(LEDAlinxAxku040PinConstraints.pins(shellInput.number)),
+      ioStandard = "LVCMOS18"
+    )
+class LEDAlinxAxku040ShellPlacer(
+  shell:          AlinxAxku040ShellBasicOverlays,
+  val shellInput: LEDShellInput
+)(
+  implicit val valName: ValName)
+    extends LEDShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  def place(designInput: LEDDesignInput) =
+    new LEDAlinxAxku040PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class JTAGDebugBScanAlinxAxku040PlacedOverlay(
+  val shell:       AlinxAxku040ShellBasicOverlays,
+  name:            String,
+  val designInput: JTAGDebugBScanDesignInput,
+  val shellInput:  JTAGDebugBScanShellInput)
+    extends JTAGDebugBScanXilinxPlacedOverlay(name, designInput, shellInput)
+class JTAGDebugBScanAlinxAxku040ShellPlacer(
+  val shell:      AlinxAxku040ShellBasicOverlays,
+  val shellInput: JTAGDebugBScanShellInput
+)(
+  implicit val valName: ValName)
+    extends JTAGDebugBScanShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  def place(designInput: JTAGDebugBScanDesignInput) =
+    new JTAGDebugBScanAlinxAxku040PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class DDRAlinxAxku040PlacedOverlay(
+  val shell:       AlinxAxku040ShellBasicOverlays,
+  name:            String,
+  val designInput: DDRDesignInput,
+  val shellInput:  DDRShellInput)
+    extends DDRPlacedOverlay[AlinxAxku040MIGDDRPads](name, designInput, shellInput) {
+  private val mig = LazyModule(
+    new AlinxAxku040MIG(AlinxAxku040MIGParams(address = AddressSet.misaligned(di.baseAddress, 0x40000000L * 2)))
+  )
+
+  override def overlayOutput: DDROverlayOutput = DDROverlayOutput(ddr = mig.node)
+  override def ioFactory = new AlinxAxku040MIGDDRPads
+
+  private val ddrIONode = BundleBridgeSource(() => mig.module.ddr4_port.cloneType)
+  private val ddrIOSink = shell { ddrIONode.makeSink() }
+  private val auxIONode = BundleBridgeSource(() => mig.module.auxio.cloneType)
+  private val auxIOSink = shell { auxIONode.makeSink() }
+  private val ddrUIClockNode = shell { ClockSourceNode(freqMHz = 200.0) }
+  private val ddrBusAreset = shell { ClockSinkNode(Seq(ClockSinkParameters())) }
+
+  val placedAuxIO = InModuleBody { Wire(mig.module.auxio.cloneType) }
+
+  ddrBusAreset := designInput.wrangler := ddrUIClockNode
+
+  InModuleBody {
+    placedAuxIO := DontCare
+    placedAuxIO <> mig.module.auxio
+    ddrIONode.bundle <> mig.module.ddr4_port
+    auxIONode.bundle <> mig.module.auxio
+  }
+
+  shell {
+    InModuleBody {
+      require(shell.sys_clock.get().isDefined, "Use of DDR overlay depends on System clock overlay")
+      io <> ddrIOSink.bundle
+
+      val (sys_clk, _) = shell.sys_clock.get().get.overlayOutput.node.out.head
+      val (ui_node, _) = ddrUIClockNode.out.head
+      val (areset_port, _) = ddrBusAreset.in.head
+      val auxio = auxIOSink.bundle
+      ui_node.clock := auxio.UIClock
+      ui_node.reset := auxio.UISyncedReset
+
+      auxio.sysClockInput := sys_clk.clock
+      auxio.sysResetInput := sys_clk.reset
+      auxio.AXIaresetn := !areset_port.reset
+
+      // format: off
+      val allddrpins = Seq(
+        // ck_c, ck_t, cke, cs_n, act_n, odt
+        "AE15", "AE16", "AJ16", "AE18", "AF18", "AG19",
+        // adr
+        "AG14", "AF17", "AF15", "AJ14", "AD18", "AG17", "AE17", "AK18",
+        "AD16", "AH18", "AD19", "AD15", "AH16", "AL17", "AL15", "AL19",
+        "AM19",
+        // ba, bg
+        "AG15", "AL18", "AJ15",
+        // reset_n
+        "AG16",
+        // dqs_c
+        "AH21", "AJ25", "AK20", "AP21", "AL28", "AP30", "AJ33", "AP34",
+        // dqs_t
+        "AG21", "AH24", "AJ20", "AP20", "AL27", "AN29", "AH33", "AN34",
+        // dq
+        "AE20", "AG20", "AF20", "AE22", "AD20", "AG22", "AF22", "AE23",
+        "AF24", "AJ23", "AF23", "AH23", "AG25", "AJ24", "AG24", "AH22",
+        "AK22", "AL22", "AM20", "AL23", "AK23", "AL25", "AL20", "AL24",
+        "AM22", "AP24", "AN22", "AN24", "AN23", "AP25", "AP23", "AM24",
+        "AM26", "AJ28", "AM27", "AK28", "AH27", "AH28", "AK26", "AK27",
+        "AN28", "AM30", "AP28", "AM29", "AN27", "AL30", "AL29", "AP29",
+        "AK31", "AH34", "AK32", "AJ31", "AJ30", "AH31", "AJ34", "AH32",
+        "AN31", "AL34", "AN32", "AN33", "AM32", "AM34", "AP31", "AP33",
+        // dm_dbi_n
+        "AD21", "AE25", "AJ21", "AM21", "AH26", "AN26", "AJ29", "AL32",
+      )
+
+      (IOPin.of(io) zip allddrpins).foreach { case (io, pin) => shell.xdc.addPackagePin(io, pin) }
+      // format: on
+    }
+  }
+}
+class DDRAlinxAxku040ShellPlacer(
+  shell:          AlinxAxku040ShellBasicOverlays,
+  val shellInput: DDRShellInput
+)(
+  implicit val valName: ValName)
+    extends DDRShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  def place(designInput: DDRDesignInput) =
+    new DDRAlinxAxku040PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class I2CAlinxAxku040PlacedOverlay(val shell: AlinxAxku040ShellBasicOverlays, name: String, val designInput: I2CDesignInput, val shellInput: I2CShellInput)
+  extends I2CXilinxPlacedOverlay(name, designInput, shellInput) {
+  shell { InModuleBody {
+    shell.xdc.addPackagePin(IOPin(io.sda), "P25")
+    shell.xdc.addPackagePin(IOPin(io.scl), "P24")
+    shell.xdc.addIOStandard(IOPin(io.sda), "LVCMOS18")
+    shell.xdc.addIOStandard(IOPin(io.scl), "LVCMOS18")
+  }}
+}
+
+class I2CAlinxAxku040ShellPlacer(val shell: AlinxAxku040ShellBasicOverlays, val shellInput: I2CShellInput)(implicit val valName: ValName)
+extends I2CShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  def place(designInput: I2CDesignInput) = new I2CAlinxAxku040PlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+abstract class AlinxAxku040ShellBasicOverlays()(implicit p: Parameters) extends UltraScaleShell {
+  val sys_clock = Overlay(ClockInputOverlayKey, new SysClockAlinxAxku040ShellPlacer(this, ClockInputShellInput()))
+  val gt_ref_clock = Overlay(ClockInputOverlayKey, new RefClockAlinxAxku040Placer(this, ClockInputShellInput()))
+  val led = Seq.tabulate(4)(i =>
+    Overlay(
+      LEDOverlayKey,
+      new LEDAlinxAxku040ShellPlacer(this, LEDShellInput(color = "red", number = i))(valName = ValName(s"led_$i"))
+    )
+  )
+  val qspi = Overlay(SPIFlashOverlayKey, new SPIFlashAlinxAxku040Placer(this, SPIFlashShellInput()))
+  val jtag_bscan =
+    Overlay(JTAGDebugBScanOverlayKey, new JTAGDebugBScanAlinxAxku040ShellPlacer(this, JTAGDebugBScanShellInput()))
+  val ddr = Overlay(DDROverlayKey, new DDRAlinxAxku040ShellPlacer(this, DDRShellInput()))
+  val i2c = Overlay(I2COverlayKey, new I2CAlinxAxku040ShellPlacer(this, I2CShellInput()))
+
+  val pllReset = InModuleBody { Wire(Bool()) }
+}
+
+class UARTAlinxAxku040FmcPlacedOverlay(val shell: AlinxAxku040ShellBasicOverlays, name: String, val designInput: UARTDesignInput, val shellInput: UARTShellInput)
+extends UARTXilinxPlacedOverlay(name, designInput, shellInput, false) {
+  shell { InModuleBody {
+    val packagePinsAndIOs = Seq(
+      ("T24", IOPin(io.rxd)), // LPC2_LA20_P (J2 36)
+      ("T25", IOPin(io.txd))  // LPC2_LA20_N (J2 35)
+    )
+
+    packagePinsAndIOs.foreach { case (pin, io) =>
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addIOB(io)
+    }
+  }}
+}
+class UARTAlinxAxku040FmcPlacer(val shell: AlinxAxku040ShellBasicOverlays, val shellInput: UARTShellInput)(implicit val valName: ValName)
+extends UARTShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  override def place(designInput: UARTDesignInput) = new UARTAlinxAxku040FmcPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+class JTAGDebugAlinxAxku040FmcPlacedOverlay(val shell: AlinxAxku040ShellBasicOverlays, name: String, val designInput: JTAGDebugDesignInput, val shellInput: JTAGDebugShellInput)
+extends JTAGDebugXilinxPlacedOverlay(name, designInput, shellInput)
+{
+  shell { InModuleBody {
+    val packagePinsAndIOs = Seq(
+      ("AH13", IOPin(io.jtag_TDI)), // LPC2_LA06_P (J3 34)
+      ("AJ13", IOPin(io.jtag_TDO)), // LPC2_LA06_N
+      ("AF10", IOPin(io.jtag_TCK)), // LPC2_LA01_P (J3 36, clock capable)
+      ("AG10", IOPin(io.jtag_TMS))  // LPC2_LA01_N
+    )
+
+    shell.sdc.addClock("jtag_TCK", IOPin(io.jtag_TCK), 10.0)
+    shell.sdc.addGroup(clocks = Seq("jtag_TCK"))
+
+    packagePinsAndIOs.foreach { case (pin, io) =>
+      shell.xdc.addPackagePin(io, pin)
+      shell.xdc.addIOStandard(io, "LVCMOS18")
+      shell.xdc.addPullup(io)
+      shell.xdc.addIOB(io)
+    }
+  }}
+}
+class JTAGDebugAlinxAxku040FmcPlacer(val shell: AlinxAxku040ShellBasicOverlays, val shellInput: JTAGDebugShellInput)(implicit val valName: ValName)
+extends JTAGDebugShellPlacer[AlinxAxku040ShellBasicOverlays] {
+  override def place(designInput: JTAGDebugDesignInput) = new JTAGDebugAlinxAxku040FmcPlacedOverlay(shell, valName.name, designInput, shellInput)
+}
+
+// HACK: pull the enable pin of the chip powers the FMC connector
+case object FmcPwrEnableOverlayKey extends Field[Seq[DesignPlacer[Null, Null, Null]]](Nil)
+
+class AlinxAxku040Fmc2PwrEnableOverlay(val shell: AlinxAxku040ShellBasicOverlays, val name: String, val designInput: Null = null, val shellInput: Null = null)
+extends IOPlacedOverlay[Bool, Null, Null, Null] {
+  override def ioFactory: Bool = Bool()
+  override def overlayOutput: Null = null
+
+  shell { InModuleBody {
+    shell.xdc.addPackagePin(IOPin(io), "L17")
+    shell.xdc.addIOStandard(IOPin(io), "LVCMOS18")
+    io := true.B
+  }}
+}
+
+class AlinxAxku040Fmc2PwrEnablePlacer(val shell: AlinxAxku040ShellBasicOverlays, val shellInput: Null = null)(implicit val valName: ValName)
+extends ShellPlacer[Null, Null, Null] {
+  override def place(di: Null) = new AlinxAxku040Fmc2PwrEnableOverlay(shell, valName.name)
+}
+
+class AlinxAxku040Shell()(implicit p: Parameters) extends AlinxAxku040ShellBasicOverlays {
+  val uart_fmc = Overlay(UARTOverlayKey, new UARTAlinxAxku040FmcPlacer(this, UARTShellInput()))
+  val jtag_fmc = Overlay(JTAGDebugOverlayKey, new JTAGDebugAlinxAxku040FmcPlacer(this, JTAGDebugShellInput()))
+  val pwr_fmc = Overlay(FmcPwrEnableOverlayKey, new AlinxAxku040Fmc2PwrEnablePlacer(this, null))
+  val topDesign = LazyModule(p(DesignKey)(designParameters))
+
+  // Place the sys_clock at the Shell if the user didn't ask for it
+  designParameters(ClockInputOverlayKey).foreach { unused =>
+    if (unused.name == "sys_clock") {
+      val source = unused.place(ClockInputDesignInput()).overlayOutput.node
+      val sink = ClockSinkNode(Seq(ClockSinkParameters()))
+      sink := source
+    }
+  }
+
+  designParameters(FmcPwrEnableOverlayKey).foreach { unused =>
+    unused.place(null)
+  }
+
+  override lazy val module = new LazyRawModuleImp(this) {
+    val sysclk = sys_clock.get() match {
+      case Some(x: SysClockAlinxAxku040PlacedOverlay) => x.clock
+    }
+
+    val powerOnReset: Bool = PowerOnResetFPGAOnly(sysclk)
+    sdc.addAsyncPath(Seq(powerOnReset))
+
+    pllReset := powerOnReset
+  }
+}

--- a/xilinx/alinx_axku040/constraints/alinx_axku040.xdc
+++ b/xilinx/alinx_axku040/constraints/alinx_axku040.xdc
@@ -1,0 +1,4 @@
+set_property BITSTREAM.GENERAL.COMPRESS TRUE          [current_design]
+set_property CFGBVS VCCO                              [current_design]
+set_property CONFIG_VOLTAGE 3.3                       [current_design]
+set_property CONFIG_MODE SPIx4                        [current_design]

--- a/xilinx/alinx_axku040/tcl/board.tcl
+++ b/xilinx/alinx_axku040/tcl/board.tcl
@@ -1,0 +1,3 @@
+set name {alinx-axku040}
+set part_fpga {xcku040-ffva1156-2-i}
+set part_board {}


### PR DESCRIPTION
Add initial support for Alinx AXKU040 development board (c.f. https://www.xilinx.com/products/boards-and-kits/1-1jl2mnw.html).

Currently following overlays are mapped:

- [x] system clock
- [x] GT reference clock
- [x] SD card
- [x] DRAM (by MIG)
- [x] JTAG and GPIO interface (by FMC addon card sold by Alinx at https://www.alinx.com/en/detail/316 )
- [ ] SPF
- [ ] ethernet
- [ ] HDMI