### PR TITLE
Fix LazyModuleImp compile error in AXKU040

### DIFF
--- a/src/main/scala/devices/xilinx/allinxaxku040mig/AlinxAxku040MIG.scala
+++ b/src/main/scala/devices/xilinx/allinxaxku040mig/AlinxAxku040MIG.scala
@@ -46,7 +46,9 @@ class AlinxAxku040MIGIsland(c: AlinxAxku040MIGParams)(implicit p: Parameters)
       )
     )
   )
-  lazy val module = new LazyModuleImp(this) {
+  lazy val module = new Impl
+
+  class Impl extends LazyModuleImp(this) {
 
     val auxio = IO(new AlinxAxku040MIGAuxPads)
     val ddr4_port = IO(new AlinxAxku040MIGDDRPads)
@@ -121,7 +123,9 @@ class AlinxAxku040MIG(c: AlinxAxku040MIGParams)(implicit p: Parameters) extends 
   val node: TLInwardNode = buffer.node
   island.crossAXI4In(island.node) := yank.node := deint.node := indexer.node := toaxi4.node := buffer.node
 
-  lazy val module = new LazyModuleImp(this) {
+  lazy val module = new Impl
+
+  class Impl extends LazyModuleImp(this) {
     val auxio = IO(new AlinxAxku040MIGAuxPads)
     val ddr4_port = IO(new AlinxAxku040MIGDDRPads).suggestName("c0_ddr4")
 


### PR DESCRIPTION
Fix the following compile error:

```text
[error] rocket-chip-fpga-shells/src/main/scala/devices/xilinx/allinxaxku040mig/AlinxAxku040MIG.scala:128:28: value auxio is not a member of freechips.rocketchip.diplomacy.LazyModuleImp
[error] did you mean auto?
[error]     auxio <> island.module.auxio
[error]                            ^
[error] rocket-chip-fpga-shells/src/main/scala/devices/xilinx/allinxaxku040mig/AlinxAxku040MIG.scala:129:32: value ddr4_port is not a member of freechips.rocketchip.diplomacy.LazyModuleImp
[error]     ddr4_port <> island.module.ddr4_port
[error]                                ^
```