### PR TITLE
Fold HasPeripheryDebugModuleImp into HasPeripheryDebug

### DIFF
--- a/src/main/scala/shell/microsemi/PolarFireEvalKitShell.scala
+++ b/src/main/scala/shell/microsemi/PolarFireEvalKitShell.scala
@@ -610,7 +610,7 @@ abstract class PolarFireEvalKitShell(implicit val p: Parameters) extends RawModu
   fpga_jtag.io.UTDODRV_2   := UInt("b0")
   fpga_jtag.io.UTDODRV_3   := UInt("b0")
   
-  def connectDebugJTAG(dut: HasPeripheryDebugModuleImp): SystemJTAGIO = {
+  def connectDebugJTAG(dut: HasPeripheryDebug): SystemJTAGIO = {
     val djtag     = dut.debug.systemjtag.get
 
     djtag.jtag.TCK          := fpga_jtag.io.TGT_TCK

--- a/src/main/scala/shell/xilinx/ArtyShell.scala
+++ b/src/main/scala/shell/xilinx/ArtyShell.scala
@@ -181,7 +181,7 @@ abstract class ArtyShell(implicit val p: Parameters) extends RawModule {
   // Debug JTAG
   //---------------------------------------------------------------------
 
-  def connectDebugJTAG(dut: HasPeripheryDebugModuleImp): SystemJTAGIO = {
+  def connectDebugJTAG(dut: HasPeripheryDebug): SystemJTAGIO = {
 
     require(dut.debug.isDefined, "Connecting JTAG requires that debug module exists")
     //-------------------------------------------------------------------

--- a/src/main/scala/shell/xilinx/VC707Shell.scala
+++ b/src/main/scala/shell/xilinx/VC707Shell.scala
@@ -63,7 +63,7 @@ trait HasDebugJTAG { this: VC707Shell =>
   val jtag_TDI             = IO(Input(Bool()))
   val jtag_TDO             = IO(Output(Bool()))
 
-  def connectDebugJTAG(dut: HasPeripheryDebugModuleImp, fmcxm105: Boolean = true): SystemJTAGIO = {
+  def connectDebugJTAG(dut: HasPeripheryDebug, fmcxm105: Boolean = true): SystemJTAGIO = {
   
     require(dut.debug.isDefined, "Connecting JTAG requires that debug module exists")
     ElaborationArtefacts.add(

--- a/src/main/scala/shell/xilinx/VCU118Shell.scala
+++ b/src/main/scala/shell/xilinx/VCU118Shell.scala
@@ -204,7 +204,7 @@ abstract class VCU118Shell(implicit val p: Parameters) extends RawModule {
   // Debug JTAG
   //---------------------------------------------------------------------
 
-  def connectDebugJTAG(dut: HasPeripheryDebugModuleImp): SystemJTAGIO = {
+  def connectDebugJTAG(dut: HasPeripheryDebug): SystemJTAGIO = {
     require(dut.debug.isDefined, "Connecting JTAG requires that debug module exists")
     val djtag     = dut.debug.get.systemjtag.get
     djtag.jtag.TCK := jtag_TCK


### PR DESCRIPTION
Replace `HasPeripheryDebugModuleImp` with `HasPeripheryDebug` based on https://github.com/chipsalliance/rocket-chip/commit/a2682ca382f5343f3478324ae2dbe7525582c7e1.