### PR TITLE
Fixes for latest rocket-chip

### DIFF
--- a/src/main/scala/shell/ButtonOverlay.scala
+++ b/src/main/scala/shell/ButtonOverlay.scala
@@ -21,9 +21,8 @@ abstract class ButtonPlacedOverlay(
 
   def ioFactory = Input(Bool())
 
-  val buttonSource = shell { BundleBridgeSource(() => Bool()) }
-  val buttonSink = buttonSource.makeSink()
-  def overlayOutput = ButtonOverlayOutput(but = InModuleBody { buttonSink.bundle })
+  val buttonWire = shell { InModuleBody(Wire(Bool())) }
+  def overlayOutput = ButtonOverlayOutput(but = buttonWire)
 }
 
 /*

--- a/src/main/scala/shell/LEDOverlay.scala
+++ b/src/main/scala/shell/LEDOverlay.scala
@@ -23,9 +23,8 @@ abstract class LEDPlacedOverlay(
 
   def ioFactory = Output(Bool())
 
-  val ledSource = BundleBridgeSource(() => Bool())
-  val ledSink = shell { ledSource.makeSink() }
-  def overlayOutput = LEDOverlayOutput(InModuleBody { ledSource.out(0)._1 })
+  val ledWire = shell { InModuleBody { Wire(Bool()) } }
+  def overlayOutput = LEDOverlayOutput(ledWire)
 }
 
 /*

--- a/src/main/scala/shell/SwitchOverlay.scala
+++ b/src/main/scala/shell/SwitchOverlay.scala
@@ -18,9 +18,8 @@ abstract class SwitchPlacedOverlay(
 
   def ioFactory = Input(Bool())
 
-  val switchSource = shell { BundleBridgeSource(() => Bool()) }
-  val switchSink = switchSource.makeSink()
-  def overlayOutput = SwitchOverlayOutput(sw = InModuleBody { switchSink.bundle } )
+  val switchWire = shell { InModuleBody { Wire(Bool()) }}
+  def overlayOutput = SwitchOverlayOutput(sw = switchWire)
 }
 
 /*

--- a/src/main/scala/shell/microsemi/LEDOverlay.scala
+++ b/src/main/scala/shell/microsemi/LEDOverlay.scala
@@ -10,7 +10,7 @@ package sifive.fpgashells.shell.microsemi
   val width = pins.size
 
    shell { InModuleBody {
-    io := ledSink.bundle // could/should put OBUFs here?
+    io := ledWire // could/should put OBUFs here?
     (pins zip IOPin.of(io)) foreach { case (pin, io) => shell.io_pdc.addPin(io, pin) }
   } }
 }

--- a/src/main/scala/shell/xilinx/ButtonOverlay.scala
+++ b/src/main/scala/shell/xilinx/ButtonOverlay.scala
@@ -12,7 +12,7 @@ abstract class ButtonXilinxPlacedOverlay(name: String, di: ButtonDesignInput, si
 
   shell { InModuleBody {
     val but  = Wire(Bool())
-    buttonSource.out(0)._1 := but
+    buttonWire := but
     val ibuf = Module(new IBUF)
     ibuf.suggestName(s"button_ibuf_${si.number}")
     ibuf.io.I := io

--- a/src/main/scala/shell/xilinx/LEDOverlay.scala
+++ b/src/main/scala/shell/xilinx/LEDOverlay.scala
@@ -9,7 +9,7 @@ abstract class LEDXilinxPlacedOverlay(name: String, di: LEDDesignInput, si: LEDS
   def shell: XilinxShell
 
   shell { InModuleBody {
-    io := ledSink.bundle // could/should put OBUFs here?
+    io := ledWire // could/should put OBUFs here?
 
     require((boardPin.isEmpty || packagePin.isEmpty), "can't provide both boardpin and packagepin, this is ambiguous")
     val cutAt = if(boardPin.isDefined) 1 else 0

--- a/src/main/scala/shell/xilinx/SwitchOverlay.scala
+++ b/src/main/scala/shell/xilinx/SwitchOverlay.scala
@@ -12,7 +12,7 @@ abstract class SwitchXilinxPlacedOverlay(name: String, di: SwitchDesignInput, si
 
   shell { InModuleBody {
     val bwire = Wire(Bool())
-    switchSource.out(0)._1 := bwire.asUInt
+    switchWire := bwire.asUInt
     val ibuf = Module(new IBUF)
     ibuf.suggestName(s"switch_ibuf_${si.number}")
     ibuf.io.I := io


### PR DESCRIPTION
Some of the BundleBridges in the overlays were unnecessary, as the source+sink were in the same module. As far as I can tell, there was never any reason for them to be BundleBridges in the first place.

Replace these BundleBridges with plain `Wire` to simplify.